### PR TITLE
feat (script.js): Muestra los precios en € por defecto y cambia a $ s…

### DIFF
--- a/en/js/prices.js
+++ b/en/js/prices.js
@@ -1,78 +1,82 @@
-document.addEventListener("DOMContentLoaded", function() {
-    // Lista de idiomas que deberían ver los precios en $
-    const usdLanguages = ['en', 'us', 'gb', 'au', 'ca'];
-
-    // Diccionario de precios
-    const prices = {
-        'eur': {
-            'basic-price': '1.920 €',
-            'standar-price': '5.760 €',
-            'continuous-plan': '7.200 € /mes',
-            'project-assesment': '2.400 € /muestra',
-            'example-production': '2.400 € /colección',
-            'training-student': '400 € /alumno',
-            'training-group': '1.800 € /grupo'
-        },
-        'usd': {
-            'basic-price': '$ 2,400',
-            'standar-price': '$ 6,800',
-            'continuous-plan': '$ 7,800 /month',
-            'project-assesment': '$ 3,600 /sample',
-            'example-production': '$ 3,600 /colection',
-            'training-student': '$ 500 /student',
-            'training-group': '$ 2,400 /group'
-        }
+document.addEventListener("DOMContentLoaded", async function() {
+    // Diccionario de precios 
+    const pricesUSD = {
+        'basic-price': '$ 2,400',
+        'standar-price': '$ 6,800',
+        'continuous-plan': '$ 7,800 /month',
+        'project-assesment': '$ 3,600 /sample',
+        'example-production': '$ 3,600 /colection',
+        'training-student': '$ 500 /student',
+        'training-group': '$ 2,400 /group'
     };
 
-    // Detectar idioma navegador
-    const userLang = navigator.language || navigator.userLanguage;
-    const langPrefix = userLang.toLowerCase().split('-')[0];
-    const currency = usdLanguages.includes(langPrefix) ? 'usd' : 'eur';
-
-    // Detectar idioma página 
+    // Idioma de paǵina según la definición de lang. 
+    // Se usará para determinar el idioma de los sufijos que acompañan a los precios
     const pageLang = document.documentElement.lang.toLowerCase().startsWith('en') ? 'en' : 'es';
 
-    // Cambiar precios por ID
-    Object.keys(prices[currency]).forEach(id => {
-        const el = document.getElementById(id);
-        if(el) {
-            let price = prices[currency][id];
+    // Lista de países europeos (simplificada)
+    const europeanCountries = [
+        "ES","PT","FR","DE","IT","NL","BE","LU","AT","IE","FI","SE","NO","DK",
+        "PL","CZ","HU","GR","RO","BG","HR","SI","SK","EE","LV","LT","MT","CY"
+    ];
 
-            // =============================================================
-            // Adaptar textos detrás del precio según el idioma de la página
-            // =============================================================
-            if(price.includes('/mes') || price.includes('/month')) {
-                price = price.replace(/\/mes|\/month/, pageLang === 'en' ? '/month' : '/mes');
+    // Función para decidir si usar dólare$ o €uros
+    async function shouldUseUSD() {
+        try {
+            // Llamada API externa
+            const res = await fetch("https://ipapi.co/json/");
+            const data = await res.json();
+            if (!europeanCountries.includes(data.country)) {
+                return true; // Devuelve true si no es una zona Euro
             }
-
-            if(price.includes('/muestra') || price.includes('/sample')) {
-                price = price.replace(/\/muestra|\/sample/, pageLang === 'en' ? '/sample' : '/muestra');
-            }
-
-            if(price.includes('/colección') || price.includes('/colection')) {
-                price = price.replace(/\/colección|\/colection/, pageLang === 'en' ? '/colection' : '/colección');
-            }
-
-            if(price.includes('/alumno') || price.includes('/student')) {
-                price = price.replace(/\/alumno|\/student/, pageLang === 'en' ? '/student' : '/alumno');
-            }
-
-            if(price.includes('/grupo') || price.includes('/group')) {
-                price = price.replace(/\/grupo|\/group/, pageLang === 'en' ? '/group' : '/grupo');
-            }
-            
-            const small = el.querySelector('small');
-            if(small) {
-                small.textContent = pageLang === 'en' ? '(Up to 8 students)' : '(Hasta 8 alumnos)';
-            }
-            // =============================================================
-            // =============================================================
-
-            // Cambio contenido precio
-            el.firstChild.textContent = price;
-
-            // Cambio atributo etiqueta
-            el.value = price;
+        } catch (e) {
+            console.warn("Can't detect country by IP:", e);
+            // Fallback: idioma navegador
+            const userLang = navigator.language || navigator.userLanguage;
+            const langPrefix = userLang.toLowerCase().split('-')[0];
+            const usdLanguages = ['en', 'us', 'gb', 'au', 'ca'];
+            if (usdLanguages.includes(langPrefix)) return true;
         }
-    });
+        return false; // Por defecto EUR
+    }
+
+    // Cambiar precios
+    if (await shouldUseUSD()) {
+        Object.keys(pricesUSD).forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                let price = pricesUSD[id];
+
+                // Adaptar textos según idioma de página
+                // =====================================
+                if(price.includes('/mes') || price.includes('/month')) {
+                    price = price.replace(/\/mes|\/month/, pageLang === 'en' ? '/month' : '/mes');
+                }
+                if(price.includes('/muestra') || price.includes('/sample')) {
+                    price = price.replace(/\/muestra|\/sample/, pageLang === 'en' ? '/sample' : '/muestra');
+                }
+                if(price.includes('/colección') || price.includes('/colection')) {
+                    price = price.replace(/\/colección|\/colection/, pageLang === 'en' ? '/colection' : '/colección');
+                }
+                if(price.includes('/alumno') || price.includes('/student')) {
+                    price = price.replace(/\/alumno|\/student/, pageLang === 'en' ? '/student' : '/alumno');
+                }
+                if(price.includes('/grupo') || price.includes('/group')) {
+                    price = price.replace(/\/grupo|\/group/, pageLang === 'en' ? '/group' : '/grupo');
+                }
+                // =====================================
+
+                // Actualizar contenido
+                el.firstChild.textContent = price;
+                el.value = price;
+
+                // Determina si se debe traducir el texto que acompaña al precio por grupos del panel "Formación Equipos"
+                const small = el.querySelector('small');
+                if(small) {
+                    small.textContent = pageLang === 'en' ? '(Up to 8 students)' : '(Hasta 8 alumnos)';
+                }
+            }
+        });
+    }
 });
+

--- a/js/prices.js
+++ b/js/prices.js
@@ -1,78 +1,82 @@
-document.addEventListener("DOMContentLoaded", function() {
-    // Lista de idiomas que deberían ver los precios en $
-    const usdLanguages = ['en', 'us', 'gb', 'au', 'ca'];
-
-    // Diccionario de precios
-    const prices = {
-        'eur': {
-            'basic-price': '1.920 €',
-            'standar-price': '5.760 €',
-            'continuous-plan': '7.200 € /mes',
-            'project-assesment': '2.400 € /muestra',
-            'example-production': '2.400 € /colección',
-            'training-student': '400 € /alumno',
-            'training-group': '1.800 € /grupo'
-        },
-        'usd': {
-            'basic-price': '$ 2,400',
-            'standar-price': '$ 6,800',
-            'continuous-plan': '$ 7,800 /month',
-            'project-assesment': '$ 3,600 /sample',
-            'example-production': '$ 3,600 /colection',
-            'training-student': '$ 500 /student',
-            'training-group': '$ 2,400 /group'
-        }
+document.addEventListener("DOMContentLoaded", async function() {
+    // Diccionario de precios 
+    const pricesUSD = {
+        'basic-price': '$ 2,400',
+        'standar-price': '$ 6,800',
+        'continuous-plan': '$ 7,800 /month',
+        'project-assesment': '$ 3,600 /sample',
+        'example-production': '$ 3,600 /colection',
+        'training-student': '$ 500 /student',
+        'training-group': '$ 2,400 /group'
     };
 
-    // Detectar idioma navegador
-    const userLang = navigator.language || navigator.userLanguage;
-    const langPrefix = userLang.toLowerCase().split('-')[0];
-    const currency = usdLanguages.includes(langPrefix) ? 'usd' : 'eur';
-
-    // Detectar idioma página 
+    // Idioma de paǵina según la definición de lang. 
+    // Se usará para determinar el idioma de los sufijos que acompañan a los precios
     const pageLang = document.documentElement.lang.toLowerCase().startsWith('en') ? 'en' : 'es';
 
-    // Cambiar precios por ID
-    Object.keys(prices[currency]).forEach(id => {
-        const el = document.getElementById(id);
-        if(el) {
-            let price = prices[currency][id];
+    // Lista de países europeos (simplificada)
+    const europeanCountries = [
+        "ES","PT","FR","DE","IT","NL","BE","LU","AT","IE","FI","SE","NO","DK",
+        "PL","CZ","HU","GR","RO","BG","HR","SI","SK","EE","LV","LT","MT","CY"
+    ];
 
-            // =============================================================
-            // Adaptar textos detrás del precio según el idioma de la página
-            // =============================================================
-            if(price.includes('/mes') || price.includes('/month')) {
-                price = price.replace(/\/mes|\/month/, pageLang === 'en' ? '/month' : '/mes');
+    // Función para decidir si usar dólare$ o €uros
+    async function shouldUseUSD() {
+        try {
+            // Llamada API externa
+            const res = await fetch("https://ipapi.co/json/");
+            const data = await res.json();
+            if (!europeanCountries.includes(data.country)) {
+                return true; // Devuelve true si no es una zona Euro
             }
-
-            if(price.includes('/muestra') || price.includes('/sample')) {
-                price = price.replace(/\/muestra|\/sample/, pageLang === 'en' ? '/sample' : '/muestra');
-            }
-
-            if(price.includes('/colección') || price.includes('/colection')) {
-                price = price.replace(/\/colección|\/colection/, pageLang === 'en' ? '/colection' : '/colección');
-            }
-
-            if(price.includes('/alumno') || price.includes('/student')) {
-                price = price.replace(/\/alumno|\/student/, pageLang === 'en' ? '/student' : '/alumno');
-            }
-
-            if(price.includes('/grupo') || price.includes('/group')) {
-                price = price.replace(/\/grupo|\/group/, pageLang === 'en' ? '/group' : '/grupo');
-            }
-            
-            const small = el.querySelector('small');
-            if(small) {
-                small.textContent = pageLang === 'en' ? '(Up to 8 students)' : '(Hasta 8 alumnos)';
-            }
-            // =============================================================
-            // =============================================================
-
-            // Cambio contenido precio
-            el.firstChild.textContent = price;
-
-            // Cambio atributo etiqueta
-            el.value = price;
+        } catch (e) {
+            console.warn("Can't detect country by IP:", e);
+            // Fallback: idioma navegador
+            const userLang = navigator.language || navigator.userLanguage;
+            const langPrefix = userLang.toLowerCase().split('-')[0];
+            const usdLanguages = ['en', 'us', 'gb', 'au', 'ca'];
+            if (usdLanguages.includes(langPrefix)) return true;
         }
-    });
+        return false; // Por defecto EUR
+    }
+
+    // Cambiar precios
+    if (await shouldUseUSD()) {
+        Object.keys(pricesUSD).forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                let price = pricesUSD[id];
+
+                // Adaptar textos según idioma de página
+                // =====================================
+                if(price.includes('/mes') || price.includes('/month')) {
+                    price = price.replace(/\/mes|\/month/, pageLang === 'en' ? '/month' : '/mes');
+                }
+                if(price.includes('/muestra') || price.includes('/sample')) {
+                    price = price.replace(/\/muestra|\/sample/, pageLang === 'en' ? '/sample' : '/muestra');
+                }
+                if(price.includes('/colección') || price.includes('/colection')) {
+                    price = price.replace(/\/colección|\/colection/, pageLang === 'en' ? '/colection' : '/colección');
+                }
+                if(price.includes('/alumno') || price.includes('/student')) {
+                    price = price.replace(/\/alumno|\/student/, pageLang === 'en' ? '/student' : '/alumno');
+                }
+                if(price.includes('/grupo') || price.includes('/group')) {
+                    price = price.replace(/\/grupo|\/group/, pageLang === 'en' ? '/group' : '/grupo');
+                }
+                // =====================================
+
+                // Actualizar contenido
+                el.firstChild.textContent = price;
+                el.value = price;
+
+                // Determina si se debe traducir el texto que acompaña al precio por grupos del panel "Formación Equipos"
+                const small = el.querySelector('small');
+                if(small) {
+                    small.textContent = pageLang === 'en' ? '(Up to 8 students)' : '(Hasta 8 alumnos)';
+                }
+            }
+        });
+    }
 });
+


### PR DESCRIPTION
…egún geoIP o idioma

- Se establecen los precios en euros directamente en el HTML como valor por defecto.
- El script consulta la localización del usuario mediante la API ipapi.co.
- Si el país detectado no pertenece a Europa, se sustituyen los precios por dólares.
- En caso de fallo en la API, se utiliza el idioma del navegador como mecanismo de respaldo.
- Se mantienen las traducciones dinámicas de sufijos y del texto adicional (<small>).